### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/deployment/amazon-rekognition-custom-brand-detection.yaml
+++ b/deployment/amazon-rekognition-custom-brand-detection.yaml
@@ -55,7 +55,7 @@ Mappings:
             DisplayName: LabelingGT
     Node:
         Runtime:
-            Version: nodejs10.x
+            Version: nodejs14.x
 
 Parameters:
     AgreeFFmpegUse:
@@ -727,7 +727,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [
@@ -795,7 +795,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [
@@ -863,7 +863,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !GetAtt CodeBuildFFmpegStack.Outputs.FFmpegLayerBucket
@@ -905,7 +905,7 @@ Resources:
                 }
             ]
             CompatibleRuntimes:
-                - nodejs10.x
+                - nodejs14.x
                 - nodejs12.x
             Content:
                 S3Bucket: !Sub [

--- a/deployment/cfn-codebuild-ffmpeg-stack.yaml
+++ b/deployment/cfn-codebuild-ffmpeg-stack.yaml
@@ -17,7 +17,7 @@ Mappings:
             FFmpegCodeBuild: "%PKG_CODEBUILD_FFMPEG%"
     Node:
         Runtime:
-            Version: nodejs10.x
+            Version: nodejs14.x
     CodeBuild:
         Image:
             Name: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/deployment/cfn-webapp-stack.yaml
+++ b/deployment/cfn-webapp-stack.yaml
@@ -24,7 +24,7 @@ Mappings:
             Name: "api"
     Node:
         Runtime:
-            Version: nodejs10.x
+            Version: nodejs14.x
 
 Parameters:
     RootStackId:


### PR DESCRIPTION
CloudFormation templates in amazon-rekognition-custom-brand-detection have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.